### PR TITLE
Fix duplicate Import-Package for "io.github.toolfactory.jvm.util" #33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,12 @@
 						<Bundle-Description>${project.description}</Bundle-Description>
 						<Bundle-Version>${project.version}</Bundle-Version>
 						<Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
-						<Import-Package>javax.tools,io.github.toolfactory.jvm;version="9.6.0",io.github.toolfactory.jvm.util;version="9.6.0",org.burningwave.jvm;version="${burningwave-jvm-driver.version}";resolution:=optional,io.github.toolfactory.jvm.util,org.slf4j;version="1.7.0";resolution:=optional</Import-Package>
+						<Import-Package>
+							javax.tools,
+							io.github.toolfactory.jvm.*;version="9.6.0",
+							org.burningwave.jvm;version="${burningwave-jvm-driver.version}";resolution:=optional,
+							org.slf4j;version="1.7.0";resolution:=optional
+						</Import-Package>
 						<Multi-Release>true</Multi-Release>
     					<_dsannotations>*</_dsannotations><!-- Enable processing of OSGI DS component annotations -->
 						<_metatypeannotations>*</_metatypeannotations><!-- Enable processing of OSGI metatype annotations -->


### PR DESCRIPTION
OSGi doesn't allow the same package to be imported twice.

Before:
```
Import-Package:
	javax.tools,
	io.github.toolfactory.jvm;version="9.6.0",
	io.github.toolfactory.jvm.util;version="9.6.0",
	org.slf4j;version="1.7.0";resolution:=optional,
	org.burningwave.jvm;version="8.15.0";resolution:=optional,
	io.github.toolfactory.jvm.util
```

After:
```
Import-Package:
	javax.tools,
	io.github.toolfactory.jvm;version="9.6.0",
	io.github.toolfactory.jvm.util;version="9.6.0",
	org.slf4j;version="1.7.0";resolution:=optional,
	org.burningwave.jvm;version="8.15.0";resolution:=optional
```

I've also taken the liberty of breaking up the `Import-Package` tag into multiple lines, to make it a little bit more readable.